### PR TITLE
Change Time library include filename to TimeLib.h

### DIFF
--- a/DS3232RTC.h
+++ b/DS3232RTC.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <Wire.h>    // http://arduino.cc/en/Reference/Wire
 #include <Stream.h>  // http://arduino.cc/en/Reference/Stream
-#include <Time.h>    // http://playground.arduino.cc/Code/time
+#include <TimeLib.h> // http://playground.arduino.cc/Code/time
 
 // Based on page 11 of specs; http://www.maxim-ic.com/datasheet/index.mvp/id/4984
 #define DS3232_I2C_ADDRESS 0x68

--- a/Examples/TestRTC/TestRTC.ino
+++ b/Examples/TestRTC/TestRTC.ino
@@ -43,7 +43,7 @@ Freetronics RTC -> Freetronics Eleven
 */
 
 #include <Wire.h>  
-#include <Time.h>  
+#include <TimeLib.h>  
 #include <avr/pgmspace.h>
 #include <string.h>
 #include "DS3232RTC.h"  // DS3232 library that returns time as a time_t


### PR DESCRIPTION
The new version of avr-libc included with Arduino IDE 1.6.10/Arduino AVR
Boards 1.6.12 and later has a file named time.h. This causes that file
to be
included instead of the intended file on case insensitive operating
systems, resulting in compile failure. This is also an issue with
non-AVR boards. Recent versions of the Time library have a file named
TimeLib.h to solve this issue.
